### PR TITLE
update romfs-wiiu.mk to make on MacOS/Darwin

### DIFF
--- a/share/romfs-wiiu.mk
+++ b/share/romfs-wiiu.mk
@@ -12,7 +12,7 @@ ROMFS_TARGET	:=	app.romfs.o
 
 %.romfs.o: $(TOPDIR)/$(ROMFS)
 	@echo ROMFS $(notdir $@)
-	$(Q)tar -H ustar -cvf romfs.tar -C $(TOPDIR)/$(ROMFS) .
+	$(Q)tar --format ustar -cvf romfs.tar -C $(TOPDIR)/$(ROMFS) .
 	$(Q)$(OBJCOPY) --input-target binary --output-target elf32-powerpc --binary-architecture powerpc:common romfs.tar $@
 	@rm -f romfs.tar
 


### PR DESCRIPTION
The tar long option --format works on both linux and Darwin/BSD, but the tar short option -H only works in linux.

% uname -v 
Darwin Kernel Version 20.2.0: Wed Dec  2 20:39:59 PST 2020; root:xnu-7195.60.75~1/RELEASE_X86_64
% tar --help  
tar(bsdtar): manipulate archive files
... 
--format {ustar|pax|cpio|shar}  Select archive format

$uname -sv
Linux #43~20.04.1-Ubuntu SMP Tue Jan 12 16:39:47 UTC 2021
$tar --help
Usage: tar [OPTION...] [FILE]...

Archive format selection:

  -H, --format=FORMAT        create archive of the given format

 FORMAT is one of the following:

    gnu                      GNU tar 1.13.x format
    oldgnu                   GNU format as per tar <= 1.12
    pax                      POSIX 1003.1-2001 (pax) format
    posix                    same as pax
    ustar                    POSIX 1003.1-1988 (ustar) format
    v7                       old V7 tar format